### PR TITLE
Fix issue with polling for new events on ScuttlebuttReadJournal events by persistence id query

### DIFF
--- a/src/main/scala/org/openlaw/scuttlebutt/persistence/ScuttlebuttAsyncWriteJournal.scala
+++ b/src/main/scala/org/openlaw/scuttlebutt/persistence/ScuttlebuttAsyncWriteJournal.scala
@@ -67,7 +67,7 @@ class ScuttlebuttAsyncWriteJournal(config: Config) extends AsyncWriteJournal {
   ) = {
     val finishedReplaysPromise = Promise[Unit]();
 
-    scuttlebuttDriver.myEventsByPersistenceId(persistenceId, fromSequenceNr, toSequenceNr, (closer: Runnable) => {
+    scuttlebuttDriver.myEventsByPersistenceId(persistenceId, fromSequenceNr, toSequenceNr, false, (closer: Runnable) => {
       new PersistentReprStreamHandler(objectMapper, scuttlebuttPersistenceSerializer, closer, recoveryCallback, finishedReplaysPromise)
     })
 

--- a/src/main/scala/org/openlaw/scuttlebutt/persistence/ScuttlebuttEventSource.scala
+++ b/src/main/scala/org/openlaw/scuttlebutt/persistence/ScuttlebuttEventSource.scala
@@ -1,0 +1,91 @@
+package org.openlaw.scuttlebutt.persistence
+
+import java.util.concurrent.{BlockingDeque, BlockingQueue, ConcurrentLinkedQueue, LinkedBlockingDeque}
+
+import akka.stream.{Attributes, Outlet, SourceShape}
+import akka.stream.stage.{AsyncCallback, GraphStage, GraphStageLogic, OutHandler}
+import org.apache.tuweni.scuttlebutt.rpc.RPCResponse
+import org.apache.tuweni.scuttlebutt.rpc.mux.ScuttlebuttStreamHandler
+import org.openlaw.scuttlebutt.persistence.driver.ScuttlebuttDriver
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.{Future, Promise, blocking}
+import scala.util.Success
+
+class ScuttlebuttEventSource(
+                               scuttlebuttDriver: ScuttlebuttDriver,
+                               persistenceId: String,
+                               start: Long,
+                               end: Long,
+                               author: String,
+                               live: Boolean) extends GraphStage[SourceShape[RPCResponse]] {
+
+  val out: Outlet[RPCResponse] = Outlet("ScuttlebuttEventSource")
+
+  override def createLogic(inheritedAttributes: Attributes): GraphStageLogic = {
+    new GraphStageLogic(shape) {
+
+      val downStreamEndedPromise = Promise[Boolean]()
+      val downStreamEnded = downStreamEndedPromise.future
+
+      val concurrentQueue = new LinkedBlockingDeque[Option[RPCResponse]] ()
+
+      var pushNewCallback: AsyncCallback[RPCResponse] = null;
+
+      override def preStart(): Unit = {
+        // "push" cannot be called in another thread, but we can use this mechanism
+        // to invoke it on the appropriate thread from another thread
+        pushNewCallback = getAsyncCallback(item => push(out, item))
+      }
+
+      override def postStop(): Unit = {
+        // If the downstream stopped consuming elements, we need to close the
+        // scuttlebutt stream - however, the 'stopper' is in another thread so we use
+        // a promise to future to close it in a thread safe way from the stream
+        // consuming thread
+        downStreamEndedPromise.complete(Success(true))
+      }
+
+      scuttlebuttDriver.eventsByPersistenceId(author, persistenceId, start, end, live,
+        (streamStopper) => new ScuttlebuttStreamHandler() {
+
+          downStreamEnded.foreach(_ => streamStopper.run())
+
+          override def onMessage(message: RPCResponse): Unit = {
+            concurrentQueue.put(Some(message))
+          }
+
+          override def onStreamEnd(): Unit = {
+            // Signal that there will be no more elements by populating the queue with "None"
+            // so that the source can be closed
+            concurrentQueue.put(None)
+          }
+
+          override def onStreamError(ex: Exception): Unit = {
+            fail(out, ex)
+          }
+        })
+
+      setHandler(out, new OutHandler {
+
+        override def onPull(): Unit = {
+          Future[Unit] {
+            blocking {
+              // Wait for a new item to become available over the stream before pushing it
+              val item = concurrentQueue.take()
+
+              item match {
+                case None => complete(out)
+                case Some(streamItem) => pushNewCallback.invoke(streamItem)
+              }
+            }
+          }
+        }
+
+      })
+
+    }
+  }
+
+  override def shape: SourceShape[RPCResponse] = SourceShape(out)
+}

--- a/src/main/scala/org/openlaw/scuttlebutt/persistence/driver/ScuttlebuttDriver.scala
+++ b/src/main/scala/org/openlaw/scuttlebutt/persistence/driver/ScuttlebuttDriver.scala
@@ -46,17 +46,19 @@ class ScuttlebuttDriver(
   def myEventsByPersistenceId(persistenceId: String,
                               fromSequenceNr: Long,
                               toSequenceNr: Long,
+                              live: Boolean,
                               handler: Function[Runnable, ScuttlebuttStreamHandler]) = {
 
 
     // 'null' for the author field is a shortcut for 'my ident'.
-    eventsByPersistenceId(null, persistenceId, fromSequenceNr, toSequenceNr, handler)
+    eventsByPersistenceId(null, persistenceId, fromSequenceNr, toSequenceNr, live, handler)
   }
 
   def eventsByPersistenceId(author: String,
                             persistenceId: String,
                             fromSequenceNr: Long,
                             toSequenceNr: Long,
+                            live: Boolean,
                             handler: Function[Runnable, ScuttlebuttStreamHandler]) = {
 
     val function: RPCFunction = new RPCFunction(
@@ -67,17 +69,10 @@ class ScuttlebuttDriver(
        author.asInstanceOf[Object],
       persistenceId.asInstanceOf[Object],
       fromSequenceNr.asInstanceOf[Object],
-      toSequenceNr.asInstanceOf[Object]))
+      toSequenceNr.asInstanceOf[Object],
+      live.asInstanceOf[Object]))
 
     multiplexer.openStream(request, handler)
-  }
-
-  // TODO: better query representation than an ObjectNode
-  def openQueryStream(query: ObjectNode, streamHandler: Function[Runnable, ScuttlebuttStreamHandler]) = {
-    val function: RPCFunction = new RPCFunction(util.Arrays.asList("query"), "read")
-    val request: RPCStreamRequest = new RPCStreamRequest(function, util.Arrays.asList(query))
-
-    multiplexer.openStream(request, streamHandler)
   }
 
   def currentPersistenceIds(): Future[Try[List[String]]] = {

--- a/src/main/scala/org/openlaw/scuttlebutt/persistence/reader/PageStream.scala
+++ b/src/main/scala/org/openlaw/scuttlebutt/persistence/reader/PageStream.scala
@@ -11,8 +11,6 @@ import com.typesafe.config.Config
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.blocking
 
-
-
 object PageStream {
 
   def defaultNextPage[T](start: Long, result: Seq[T]): Long = {

--- a/src/main/scala/org/openlaw/scuttlebutt/persistence/reader/ScuttlebuttStreamRangeFiller.scala
+++ b/src/main/scala/org/openlaw/scuttlebutt/persistence/reader/ScuttlebuttStreamRangeFiller.scala
@@ -1,5 +1,7 @@
 package org.openlaw.scuttlebutt.persistence.reader
 
+import akka.NotUsed
+import akka.stream.javadsl.Source
 import com.fasterxml.jackson.databind.ObjectMapper
 import org.apache.tuweni.scuttlebutt.rpc.RPCResponse
 import org.apache.tuweni.scuttlebutt.rpc.mux.ScuttlebuttStreamHandler
@@ -36,7 +38,7 @@ class ScuttlebuttStreamRangeFiller(
 
     var promise: Promise[Seq[RPCResponse]] = Promise()
 
-    driver.eventsByPersistenceId(author, persistenceId, fromSequenceNr, toSequenceNr, (stopper) => {
+    driver.eventsByPersistenceId(author, persistenceId, fromSequenceNr, toSequenceNr, false, (stopper) => {
       new ScuttlebuttStreamHandler {
         var results: Seq[RPCResponse] = Seq()
 

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.0.1-SNAPSHOT"
+version in ThisBuild := "1.0.2-SNAPSHOT"


### PR DESCRIPTION
The previous approach was leading to starvation of a global thread pool